### PR TITLE
Fixed issue with URL being built wrong when no extra path is used.

### DIFF
--- a/app/src/main/java/org/sickbeard/SickBeard.java
+++ b/app/src/main/java/org/sickbeard/SickBeard.java
@@ -20,6 +20,7 @@
 package org.sickbeard;
 
 import android.os.AsyncTask;
+import android.text.TextUtils;
 import android.util.Log;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -77,14 +78,8 @@ public class SickBeard {
 		this.port = port;
 
 		this.extraPath = "";
-        if (extraPath != null && !extraPath.equals("")) {
-
-            StringBuilder extraPathBuilder = new StringBuilder();
-            if (!extraPath.startsWith("/")) extraPathBuilder.append("/"); // Add preceding backslash only if required.
-            extraPathBuilder.append(extraPath);
-            if (extraPath.endsWith("/")) extraPathBuilder.deleteCharAt(extraPathBuilder.length() - 1); // Remove trailing backslash
-
-            this.extraPath = extraPathBuilder.toString();
+        if (!TextUtils.isEmpty(extraPath)) {
+            this.extraPath = "/" + extraPath.replaceAll("^/|/$", "");
         }
 
 		this.path = this.extraPath + "/api/" + api + "/";

--- a/app/src/main/java/org/sickbeard/SickBeard.java
+++ b/app/src/main/java/org/sickbeard/SickBeard.java
@@ -75,8 +75,20 @@ public class SickBeard {
 	{
 		this.hostname = hostname;
 		this.port = port;
-		this.extraPath = "/" + extraPath + "/";
+
+		this.extraPath = "";
+        if (extraPath != null && !extraPath.equals("")) {
+
+            StringBuilder extraPathBuilder = new StringBuilder();
+            if (!extraPath.startsWith("/")) extraPathBuilder.append("/"); // Add preceding backslash only if required.
+            extraPathBuilder.append(extraPath);
+            if (extraPath.endsWith("/")) extraPathBuilder.deleteCharAt(extraPathBuilder.length() - 1); // Remove trailing backslash
+
+            this.extraPath = extraPathBuilder.toString();
+        }
+
 		this.path = this.extraPath + "/api/" + api + "/";
+
 		try {
 			this.https = https;
 			this.scheme = "http";


### PR DESCRIPTION
URL was being built with a triple backslash (e.g. http://host:port///api/e2635.../?cmd=...). This fixes the issue and adds protection against when the user adds trailing or preceding backslashes into the extraPath setting.
